### PR TITLE
Handle unconfigure by checking for configuration index 0 in USB_DC_CONFIGURE

### DIFF
--- a/src/hid.c
+++ b/src/hid.c
@@ -158,9 +158,15 @@ static void status_cb(enum usb_dc_status_code status, const uint8_t *param)
 		configured = false;
 		break;
 	case USB_DC_CONFIGURED:
-		if (!configured) {
-			int_in_ready_cb(hdev);
-			configured = true;
+		int configurationIndex = *param;
+		if(configurationIndex == 0) {
+			// from usb_device.c: A configuration index of 0 unconfigures the device.
+			configured = false;
+		} else {
+			if (!configured) {
+				int_in_ready_cb(hdev);
+				configured = true;
+			}
 		}
 		break;
 	case USB_DC_SOF:


### PR DESCRIPTION
This allows the receiver to be used over the network/wifi using usb/ip. Which seems to unconfigure the device at some point before connecting.