### PR TITLE
Add BT33 board

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,7 @@ jobs:
                   {boardname: "etee_dongle_uf2/nrf52840", fileformat: "uf2", filename: "SlimeNRF_etee_Receiver"}, 
                   {boardname: "nrf52840dk/nrf52840", fileformat: "hex", filename: "SlimeNRF_nRF52840dk_Receiver"}, 
                   {boardname: "butterfly_p1_uf2/nrf52833", fileformat: "uf2", filename: "SlimeNRF_Butterfly_P1_Receiver"}, 
+                  {boardname: "dx_smart_bt33_uf2/nrf52833", fileformat: "uf2", filename: "SlimeNRF_Receiver_BT33"}, 
                 ]
     if: always()
     runs-on: ubuntu-latest

--- a/boards/dx-smart/dx_smart_bt33_uf2/Kconfig.dx_smart_bt33_uf2
+++ b/boards/dx-smart/dx_smart_bt33_uf2/Kconfig.dx_smart_bt33_uf2
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_DX_SMART_BT33_UF2
+	select SOC_NRF52833_QIAA

--- a/boards/dx-smart/dx_smart_bt33_uf2/board.cmake
+++ b/boards/dx-smart/dx_smart_bt33_uf2/board.cmake
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
+
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/dx-smart/dx_smart_bt33_uf2/board.yml
+++ b/boards/dx-smart/dx_smart_bt33_uf2/board.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: dx_smart_bt33_uf2
+  vendor: dx-smart
+  socs:
+    - name: nrf52833

--- a/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2.dts
+++ b/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2.dts
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Nordic Semiconductor ASA
+// SPDX-License-Identifier: Apache-2.0
+
+/dts-v1/;
+#include <nordic/nrf52833_qiaa.dtsi>
+
+//move to dtsi?
+&pinctrl {
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 3)>;
+			nordic,drive-mode = <NRF_DRIVE_D0S1>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 3)>;
+			low-power-enable;
+		};
+	};
+};
+//end
+
+/ {
+	model = "dx_smart_bt33_uf2";
+	compatible = "dx_smart_bt33_uf2";
+
+	aliases {
+		sw0 = &button0;
+		pwm-led0 = &pwm_led0;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 0";
+		};
+	};
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &cdc_acm_uart0;
+		zephyr,shell-uart = &cdc_acm_uart0;
+	};
+
+	nrf_radio_fem: GC1101 {
+	    compatible = "skyworks,sky66112-11", "generic-fem-two-ctrl-pins";
+	    ctx-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+	    ctx-settle-time-us = <1>;
+	    crx-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+	    crx-settle-time-us = <1>;
+	    tx-gain-db = <22>;
+	    rx-gain-db = <15>;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	zephyr,user {
+		led-gpios = <&gpio0 3 GPIO_OPEN_SOURCE>;
+	};
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};
+
+&nfct {
+	status = "disabled";
+};
+
+&radio {
+	fem = <&nrf_radio_fem>;
+};

--- a/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2.yaml
+++ b/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: dx_smart_bt33_uf2
+name: dx_smart_bt33_uf2
+vendor: dx_smart
+type: mcu
+arch: arm
+ram: 128
+flash: 512
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools

--- a/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2_defconfig
+++ b/boards/dx-smart/dx_smart_bt33_uf2/dx_smart_bt33_uf2_defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y
+
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_DEVICE_MANUFACTURER="SlimeVR"
+CONFIG_USB_DEVICE_PRODUCT="SlimeVR NRF Receiver BT33"
+
+#generate for adafruit uf2 bootloader flashing
+CONFIG_BUILD_OUTPUT_UF2=y
+CONFIG_FLASH_LOAD_OFFSET=0x1000

--- a/pm_static_dx_smart_bt33_uf2_nrf52833.yml
+++ b/pm_static_dx_smart_bt33_uf2_nrf52833.yml
@@ -1,0 +1,10 @@
+bootloader:
+  address: 0x0
+  end_address: 0x1000
+  region: flash_primary
+  size: 0x1000
+uf2_bootloader:
+  address: 0x74000
+  end_address: 0x80000
+  region: flash_primary
+  size: 0xc000


### PR DESCRIPTION
Product Page: https://www.aliexpress.com/item/1005008180809307.html
Spec: nrf52833 + GC1101(PA+LNA)
GC1101 https://www.geochipinc.com/product/SPQDXP/209.html

needs 3.3V for GC1101 so buy module with daughter board is preferred
use picoprobe to flash bootloader

Unlock
```bash
./openocd -d2 -f interface/cmsis-dap.cfg -f target/nrf52.cfg -c "init" -c "nrf52_recover"
```

Flash
```bash
./openocd -d2 -f interface/cmsis-dap.cfg -f target/nrf52.cfg \
-c "gdb flash_program enable" \
-c "gdb breakpoint_override hard" \
-c "init" \
-c "reset halt" \
-c "flash write_image erase ./bootloader.hex"
```

Board Infomation:

VBAT = 3.3V
fem-ctx-gpios = P0.17
fem-crx-gpios = P0.20

<img width="600" alt="image" src="https://github.com/user-attachments/assets/ef81c935-2dad-4cfb-a1ba-de0d3273d0de" />


Signal strength at 2-3m line of sight

https://github.com/user-attachments/assets/3972e7fb-049e-4a9d-bd4c-853870fd5e8c


